### PR TITLE
Build tutorial VM on top of fcrepo4-vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Scripts to build a Vagrant-based VM for running Samvera Camp tutorials.
 
 The current versions provisioned by this build script are:
 
-* Ubuntu server 16.04 LTS (bento/ubuntu-16.04)
+* Ubuntu server 14.04 LTS ( [fcrepo4-vagrant-4.7.5](https://github.com/fcrepo4-exts/fcrepo4-vagrant) )
 * rvm >= 1.29.4
 * ruby 2.5.1
 * rubygems >= 2.7.6 
@@ -16,7 +16,7 @@ The current versions provisioned by this build script are:
 * FITS 1.2.0
 * ffmpeg 3.4
 
-The build scripts also installs the gems necessary to run a Hyrax 2.1 (Beta) application:
+The build scripts also installs the gems necessary to run a Hyrax 2.3.3 application:
 
 * Solr Install files
     * version 6.6.2

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "fcrepo4-vagrant-4.7.5.box"
   # box-cutter/ubuntu1604
   #config.vm.box_url = "file:///Users/mark/Documents/workspace/_no_backup/deployinghydra/open-vagrant-boxes/ubuntu-14.04.3-amd64-vbox.box"
 

--- a/build_camp_box.yml
+++ b/build_camp_box.yml
@@ -25,7 +25,7 @@
     - { role: set_timezone, timezone: US/Pacific }
     - { role: set_hostname, hostname: camper, domain: local }
     - { role: fits }
-    - { role: ffmpeg }
+  # - { role: ffmpeg }
     - { role: imagemagick }
     - { role: rvm_io.ruby,
         rvm1_rubies: [ 'ruby-{{ ruby_version }}' ],

--- a/dce-boxes.json
+++ b/dce-boxes.json
@@ -90,12 +90,20 @@
                 "checksum": "206d3f8a1276d3eaec899160f2d0026e38a81357"
                 }]
         },{
-        "version": "67.0",
+        "version": "7.0",
         "providers": [{
                 "name": "virtualbox",
                 "url": "http://camp.curationexperts.com/vagrant-boxes/camper-v7.0.box",
                 "checksum_type": "sha1",
                 "checksum": "e6e7a2d9518df312c08a72d401793a193580cec3"
+                }]
+        },{
+        "version": "7.1",
+        "providers": [{
+                "name": "virtualbox",
+                "url": "http://camp.curationexperts.com/vagrant-boxes/camper-v7.1.box",
+                "checksum_type": "sha1",
+                "checksum": "42e28f09572532080ca1aeea275c95559d414e76"
                 }]
         }]
 }

--- a/roles/samvera-tutorials/tasks/hyrax-setup.yml
+++ b/roles/samvera-tutorials/tasks/hyrax-setup.yml
@@ -13,7 +13,7 @@
 
 - name: clone code for Duke2018 tutorials
   git: 
-    repo: https://github.com/RepoCamp/duke2018.git
+    repo: https://github.com/RepoCamp/berlin2018.git
     dest: hyrax-sample
     version: walkthrough
 
@@ -28,6 +28,7 @@
 
 - name: run redis
   service: name=redis-server state=started
+  become: yes
 
 - name: start the hyrax development server
   command: bash -lc "cd ~/hyrax-sample/ && rails hydra:server "

--- a/tutorial/Vagrantfile
+++ b/tutorial/Vagrantfile
@@ -22,18 +22,20 @@ Vagrant.configure(2) do |config|
   else
     # Use this url for web based setup
     config.vm.box_url = "http://camp.curationexperts.com/vagrant-boxes/dce-boxes.json"
-    config.vm.box_version = ">= 7.0, < 8.0"
+    config.vm.box_version = ">= 7.1, < 8.0"
   end
    
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # config.vm.network "forwarded_port", guest: 80, host: 8080
-  config.vm.network "forwarded_port", guest: 8983, host: 8983, auto_correct: true
-  config.vm.network "forwarded_port", guest: 8984, host: 8984, auto_correct: true
-  config.vm.network "forwarded_port", guest: 8985, host: 8985, auto_correct: true
-  config.vm.network "forwarded_port", guest: 8986, host: 8986, auto_correct: true
-  config.vm.network "forwarded_port", guest: 3000, host: 3000, auto_correct: true
+  config.vm.network "forwarded_port", guest: 8983, host: 8983 # Hyrax Solr Dev
+  config.vm.network "forwarded_port", guest: 8984, host: 8984 # Hyrax Fedora Dev
+  config.vm.network "forwarded_port", guest: 8985, host: 8985 # Hyrax Solr Test
+  config.vm.network "forwarded_port", guest: 8986, host: 8986 # Hyrax Fedora Test
+  config.vm.network "forwarded_port", guest: 3000, host: 3000 # Hyrax Dev Webserver
+  config.vm.network "forwarded_port", guest: 8080, host: 8080 # Tomcat
+  config.vm.network "forwarded_port", guest: 9080, host: 9080 # Fixity and Reindexing
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -62,7 +64,7 @@ Vagrant.configure(2) do |config|
     # vb.gui = true
     #
     # Use VBoxManage to customize the VM. For example to change memory:
-    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
     vb.customize ["modifyvm", :id, "--name", "Camper"]
     vb.customize ['modifyvm', :id, '--cableconnected1', 'on']
   end

--- a/tutorial/vagrant-boxes/local-boxes.json
+++ b/tutorial/vagrant-boxes/local-boxes.json
@@ -2,12 +2,12 @@
     "name": "camper",
     "description": "Ubuntu based box for Samvera tutorials and development work",
     "versions": [{
-        "version": "7.0",
+        "version": "7.1",
         "providers": [{
                 "name": "virtualbox",
-                "url": "./vagrant-boxes/camper-v7.0.box",
+                "url": "./vagrant-boxes/camper-v7.1.box",
                 "checksum_type": "sha1",
-                "checksum": "e6e7a2d9518df312c08a72d401793a193580cec3"
+                "checksum": "42e28f09572532080ca1aeea275c95559d414e76"
                 }]
         }]
 }


### PR DESCRIPTION
Builds an Ubuntu 14.04 LTS based Vagrant VM that can be used for
both Fedora and Samvera tutorials.